### PR TITLE
Fixes the 'rm' command so that it works properly from the command lin…

### DIFF
--- a/sol
+++ b/sol
@@ -36,8 +36,8 @@ program
     .command('delete <URL...>')
     .alias('rm')
     .description('delete file or recursively delete folder')
-    .action( URL => {
-        sol.runSol("delete",[URL]).then(()=>{
+    .action( URLs => {
+        sol.runSol("delete",URLs).then(()=>{
         },err=>console.log(err));
     });
 program

--- a/src/sol.run.js
+++ b/src/sol.run.js
@@ -92,22 +92,24 @@ async function runSol(com,args) {
 
         case "rm" :
         case "delete" :
-            source = mungeURL(args[0]);
-            if(!source) resolve();
-            if( source.endsWith("/") ){
-                log("\n*** deleting folder "+source)
-                fc.deleteFolder(source).then( () => {
-                    log("folder deleted")
-                    resolve()
-                },err=>{ do_err(err); resolve() })
-            }
-            else {
-                log("\n*** deleting file "+source)
-                fc.deleteFile(source).then( () => {
-                    log("file deleted\n");
-                    resolve();
-                },err=>{ do_err(err); resolve() })
-            }
+            for (const arg of args) {
+                source = mungeURL(arg);
+                if(!source) resolve();
+                if( source.endsWith("/") ){
+                    log("\n*** deleting folder "+source)
+                    fc.deleteFolder(source).then( () => {
+                        log("folder deleted")
+                        resolve()
+                    },err=>{ do_err(err); resolve() })
+                }
+                else {
+                    log("\n*** deleting file "+source)
+                    fc.deleteFile(source).then( () => {
+                        log("file deleted\n");
+                        resolve();
+                    },err=>{ do_err(err); resolve() })
+                }
+            };
             break;
 
         case "cp"   :


### PR DESCRIPTION
- Fixes the 'rm' command so that it works properly from the command line without crashing.
- Also fixes it so that within the shell, 'rm' can support multiple URLs.

Previously, using `rm` from the unix command line would crash.  For example:

```
./sol rm https://doctorbud.solidcommunity.net/public/index.html
```

And using `rm` from within the 'sol shell' would only process the first argument. For example, the following would only delete the first file:

```
./sol shell
> rm https://doctorbud.solidcommunity.net/public/index.html https://doctorbud.solidcommunity.net/public/index2.html
```